### PR TITLE
GitHub OAuth URL 수정

### DIFF
--- a/client/src/auth/github.js
+++ b/client/src/auth/github.js
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import BASE_URL from '../const/url.js';
 import axios from 'axios';
 import qs from 'qs';
 
@@ -9,7 +10,7 @@ const GitHubCallback = ({ cb, history, location }) => {
     });
 
     try {
-      const url = 'http://localhost:3000/users/login/github';
+      const url = `${BASE_URL}/users/login/github`;
       const {
         data: { token },
       } = await axios.post(url, { code });

--- a/client/src/auth/login.js
+++ b/client/src/auth/login.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import axios from 'axios';
+import BASE_URL from '../const/url.js';
 
 const LoginContainer = () => {
   const githubLoginHandler = async () => {
     const {
       data: { url },
-    } = await axios.get('http://127.0.0.1:3000/users/login/github');
+    } = await axios.get(`${BASE_URL}/users/login/github`);
 
     location.href = url;
   };

--- a/client/src/auth/login.scss
+++ b/client/src/auth/login.scss
@@ -1,0 +1,74 @@
+.login-container {
+  display: flex;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, calc(-50% - 25px));  
+  flex-direction: column;
+  align-items: center;
+  
+  & .login-title {
+    height: 50px;
+    margin: 0;
+  }
+  
+  & .login-form {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid lightgray;
+    border-radius: 5px;
+    padding: 1rem;
+    background-color: #fff;
+
+    & .form-content {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding-bottom: 7px;
+      min-width: 200px;
+
+      label {
+        font-size: 0.8rem;
+        font-weight: 500;
+        padding: 5px;
+      }
+
+      input {
+        border: 1px solid #eee;
+        border-radius: 3px;
+        padding: 3px;
+      }
+    }
+
+    & .form-sign-div {
+      display: flex;
+      width: 100%;
+      justify-content: space-evenly;
+      padding-bottom: 15px;
+
+      button {
+        border: none;
+        background-color: transparent;
+        font-weight: 500;
+        color: #4c8ce1;
+      }
+    }
+  }
+
+  & .form-github-submit {
+    padding: 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: grey;
+    border: none;
+    border-radius: 3px;
+    min-width: 200px;
+    p {
+        color: white;
+        margin: 2px 5px;
+    }
+  }
+}

--- a/client/src/const/url.js
+++ b/client/src/const/url.js
@@ -1,0 +1,5 @@
+const BASE_URL = process.env.NODE_ENV === "production"
+    ? "http://118.67.132.70:3000"
+    : "http://127.0.0.1:3000";
+
+export default BASE_URL;


### PR DESCRIPTION
# 개요
- src 아래 const 디렉토리를 만들어서, Base url을 export하는 url.js 생성
- login.js와 github.js의 callback url을 Base url 기반으로 수정

# 체크리스트
- [x] 서버 배포 후, GitHub OAuth 정상 작동