### PR TITLE
전체 라벨 조회 API 구축

### DIFF
--- a/server/main/controllers/label.js
+++ b/server/main/controllers/label.js
@@ -1,0 +1,15 @@
+const { responseHandler } = require('@/utils/handler');
+const { labelService } = require('@/services/index');
+
+class LabelController {
+  async getAllLabels(req, res, next) {
+    try {
+      const labels = await labelService.getAllLabels();
+      responseHandler(res, 200, { labels });
+    } catch (err) {
+      next(err);
+    }
+  }
+}
+
+module.exports = new LabelController();

--- a/server/main/routes/index.js
+++ b/server/main/routes/index.js
@@ -1,9 +1,11 @@
 const express = require('express');
 const usersRouter = require('@/routes/users');
 const issuesRouter = require('@/routes/issue');
+const labelRouter = require('@/routes/labels');
 const router = express.Router();
 
 router.use('/users', usersRouter);
 router.use('/issues', issuesRouter);
+router.use('/labels', labelRouter);
 
 module.exports = router;

--- a/server/main/routes/labels.js
+++ b/server/main/routes/labels.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const labelController = require('@/controllers/label');
+
+const { authenticateUser } = require('@/utils/middleware');
+const router = express.Router();
+
+router.get('/', authenticateUser, labelController.getAllLabels);
+
+module.exports = router;

--- a/server/main/services/label.js
+++ b/server/main/services/label.js
@@ -13,6 +13,16 @@ class LabelService {
       throw Error(err);
     }
   }
+  async getAllLabels() {
+    try {
+      const labels = await this.Label.findAll({
+        attributes: { exclude: ['createdAt', 'updatedAt'] },
+      });
+      return labels;
+    } catch (err) {
+      throw Error(err);
+    }
+  }
 }
 
 module.exports = new LabelService(Label);

--- a/server/test/api/label.api.test.js
+++ b/server/test/api/label.api.test.js
@@ -1,0 +1,56 @@
+/* eslint-disable jest/no-done-callback */
+const request = require('supertest');
+const app = require('@/app');
+const { expectedUserToken } = require('@test/seeds/user');
+const { expectedLabels } = require('@test/seeds/label');
+
+const SUCCESS_CODE = 200;
+const UNAUTHORIZED_CODE = 401;
+const UNAUTHORIZED_MESSAGE = 'Unauthorized';
+
+describe('retrieve all labels API test', () => {
+  const RETRIEVE_ALL_LABEL_URL = '/labels';
+
+  it('Authorized', done => {
+    // given
+    try {
+      request(app)
+        .get(RETRIEVE_ALL_LABEL_URL) // when
+        .set('Authorization', expectedUserToken)
+        .end((err, res) => {
+          if (err) {
+            throw err;
+          }
+          const { code, success, labels } = res.body;
+
+          //then
+          expect(code).toBe(SUCCESS_CODE);
+          expect(success).toBeTruthy();
+          expect(labels).toStrictEqual(expectedLabels);
+          done();
+        });
+    } catch (err) {
+      done(err);
+    }
+  });
+  it('unAuthorized', done => {
+    // given
+    try {
+      request(app)
+        .get(RETRIEVE_ALL_LABEL_URL) // when
+        .end((err, res) => {
+          if (err) {
+            throw err;
+          }
+          const { code, message } = res.body;
+
+          //then
+          expect(code).toBe(UNAUTHORIZED_CODE);
+          expect(message).toBe(UNAUTHORIZED_MESSAGE);
+          done();
+        });
+    } catch (err) {
+      done(err);
+    }
+  });
+});

--- a/server/test/services/label.test.js
+++ b/server/test/services/label.test.js
@@ -15,4 +15,16 @@ describe('Total Labels', () => {
     },
     TIMEOUT
   );
+  test('retrieve all labels', async () => {
+    //given
+    //when
+    const labels = await labelService.getAllLabels();
+    const recievedLabels = labels.map(label => {
+      const copy = Object.assign({}, label.dataValues);
+      return copy;
+    });
+
+    //then
+    expect(recievedLabels).toStrictEqual(expectedLabels);
+  });
 });


### PR DESCRIPTION
- 개요
   - 전체 라벨 조회 API 구축
   - 상세 페이지의 Labels를 위한 API
   - 테스트 코드에 따른 기능 구현
- 체크리스트
   - [x] 사용자 인증이 된 경우, 200 status와 success, labels 배열을 반환
   - [x] 사용자 인증이 안된 경우, 401 error 반환
   - [x] 내부 오류 발생 시, 500 Error를 반환