### PR TITLE
[#80] Issue 제목 수정 API

### DIFF
--- a/server/main/controllers/issue.js
+++ b/server/main/controllers/issue.js
@@ -102,6 +102,23 @@ class IssueController {
     }
   }
 
+  async updateIssueTitle(req, res, next) {
+    const title = req.body && req.body.title;
+    if (!title || typeof title !== 'string') {
+      // 빈 문자열도 거부
+      const err = new Error('Bad Request');
+      err.status = 400;
+      return next(err);
+    }
+
+    try {
+      if (await issueService.updateTitle(req.params.issueID, title))
+        responseHandler(res, 200);
+    } catch (err) {
+      next(err);
+    }
+  }
+
   isValidParams(req, res, next) {
     const err = new Error('Bad Request');
     err.status = 400;

--- a/server/main/routes/issue.js
+++ b/server/main/routes/issue.js
@@ -22,6 +22,13 @@ router.get(
   issueController.getIssueDetails
 );
 
+router.patch(
+  '/:issueID',
+  authenticateUser,
+  isValidIssueID,
+  issueController.updateIssueTitle
+);
+
 router.post(
   '/:issueID/comments',
   authenticateUser,

--- a/server/main/services/issue.js
+++ b/server/main/services/issue.js
@@ -62,6 +62,9 @@ class IssueService {
       throw Error(err);
     }
   }
+  async updateTitle(issueID, title) {
+    return (await this.Issue.update({ title }, { where: { id: issueID } }))[0];
+  }
 }
 
 module.exports = new IssueService(Issue);

--- a/server/test/api/issue.api.test.js
+++ b/server/test/api/issue.api.test.js
@@ -4,7 +4,7 @@ const app = require('@/app');
 const { users, expectedUserToken } = require('@test/seeds/user');
 const { expectedLabels } = require('@test/seeds/label');
 const { status } = require('@test/api/response-status');
-const { issueIds } = require('@test/seeds/issue');
+const { issueIds, expectedIssue } = require('@test/seeds/issue');
 const { DEFAULT_PROFILE_IMAGE_URL } = require('@/utils/auth');
 
 describe('retrieve all issues', () => {
@@ -145,6 +145,43 @@ describe('retrieve issue details', () => {
           const { code, message } = res.body;
           expect(code).toBe(status.code.UNAUTHORIZED);
           expect(message).toBe(status.message.UNAUTHORIZED);
+          done();
+        });
+    } catch (err) {
+      done(err);
+    }
+  });
+});
+
+describe('update title of an issue', () => {
+  const ISSUE_DETAIL_URL = `/issues/${expectedIssue.id}`;
+  const data = { title: '우욱' };
+
+  it('successfully', done => {
+    try {
+      request(app)
+        .patch(ISSUE_DETAIL_URL)
+        .set('Authorization', expectedUserToken)
+        .send(data)
+        .end((err, res) => {
+          const { code } = res.body;
+          expect(code).toBe(status.code.SUCCESS);
+          done();
+        });
+    } catch (err) {
+      done(err);
+    }
+  });
+
+  it('with invalid title', done => {
+    try {
+      request(app)
+        .patch(ISSUE_DETAIL_URL)
+        .set('Authorization', expectedUserToken)
+        .send({ data: { title: '?' } })
+        .end((err, res) => {
+          const { code } = res.body;
+          expect(code).toBe(status.code.BAD_REQUEST);
           done();
         });
     } catch (err) {

--- a/server/test/api/issue.api.test.js
+++ b/server/test/api/issue.api.test.js
@@ -4,7 +4,7 @@ const app = require('@/app');
 const { users, expectedUserToken } = require('@test/seeds/user');
 const { expectedLabels } = require('@test/seeds/label');
 const { status } = require('@test/api/response-status');
-const { issueIds, expectedIssue } = require('@test/seeds/issue');
+const { issueIds, otherIssue } = require('@test/seeds/issue');
 const { DEFAULT_PROFILE_IMAGE_URL } = require('@/utils/auth');
 
 describe('retrieve all issues', () => {
@@ -154,7 +154,7 @@ describe('retrieve issue details', () => {
 });
 
 describe('update title of an issue', () => {
-  const ISSUE_DETAIL_URL = `/issues/${expectedIssue.id}`;
+  const ISSUE_DETAIL_URL = `/issues/${otherIssue.id}`;
   const data = { title: '우욱' };
 
   it('successfully', done => {

--- a/server/test/seeds/issue.js
+++ b/server/test/seeds/issue.js
@@ -29,6 +29,7 @@ const issues = [
 ];
 
 const expectedIssue = issues[1];
+const otherIssue = issues[3];
 
 const issueIds = new Set();
 issues.forEach(issue => issueIds.add(issue.id));
@@ -41,4 +42,10 @@ const finiIssues = async () => {
   await Issue.destroy({ where: {} });
 };
 
-module.exports = { initIssues, finiIssues, expectedIssue, issueIds };
+module.exports = {
+  initIssues,
+  finiIssues,
+  expectedIssue,
+  otherIssue,
+  issueIds,
+};

--- a/server/test/services/issue.test.js
+++ b/server/test/services/issue.test.js
@@ -2,7 +2,7 @@ const TIMEOUT = 10000;
 const NONEXISTING_ID = 99999;
 
 const { issueService } = require('@/services/index');
-const { expectedIssue, issueIds } = require('@test/seeds/issue');
+const { expectedIssue, otherIssue, issueIds } = require('@test/seeds/issue');
 const { Issue } = require('@/models');
 
 describe('retrieve', () => {
@@ -80,7 +80,7 @@ describe('create issue', () => {
 describe('update', () => {
   test('update title', async () => {
     const data = {
-      id: 1,
+      id: otherIssue.id,
       title: '수정 테스트',
     };
     const updateResult = await issueService.updateTitle(data.id, data.title);

--- a/server/test/services/issue.test.js
+++ b/server/test/services/issue.test.js
@@ -83,7 +83,7 @@ describe('update', () => {
       id: 1,
       title: '수정 테스트',
     };
-    const updateResult = await issueService.updateIssue(data.id, data.title);
+    const updateResult = await issueService.updateTitle(data.id, data.title);
     expect(updateResult).toBeTruthy();
     const { title } = (await Issue.findByPk(data.id)).dataValues;
     expect(title).toBe(data.title);

--- a/server/test/services/issue.test.js
+++ b/server/test/services/issue.test.js
@@ -3,6 +3,7 @@ const NONEXISTING_ID = 99999;
 
 const { issueService } = require('@/services/index');
 const { expectedIssue, issueIds } = require('@test/seeds/issue');
+const { Issue } = require('@/models');
 
 describe('retrieve', () => {
   test(
@@ -79,10 +80,12 @@ describe('create issue', () => {
 describe('update', () => {
   test('update title', async () => {
     const data = {
-      id: 2,
+      id: 1,
       title: '수정 테스트',
     };
-    const updateResult = await issueService.updateIssue(data);
-    expect(updateResult).toBe(true);
+    const updateResult = await issueService.updateIssue(data.id, data.title);
+    expect(updateResult).toBeTruthy();
+    const { title } = (await Issue.findByPk(data.id)).dataValues;
+    expect(title).toBe(data.title);
   });
 });


### PR DESCRIPTION
# 개요
- 여전히 남아있던 test 실행 순서 dependency 완화
- Issue 제목 수정 API 구현

# 체크리스트
- [x] 로그인된 사용자로 title을 주면 제목이 바뀌는 것을 확인
- [x] title이 없거나(400) 해당 id의 issue가 없거나(404) 로그인하지 않은 경우(401) 거부되는 것도 확인